### PR TITLE
Update checks list: remove 14470 through 14501

### DIFF
--- a/projects/checks.html
+++ b/projects/checks.html
@@ -6,11 +6,6 @@ title: Current Projects
       <section>
       <h1>The Narcotics Audit: 1505 <p>Checks Yet To Request</h1>
       <h2>A joint project with MuckRock</h2>
-<p>Check #14470 dated 01/20/2010 for the amount $127087.81</p>
-<p>Check #14471 dated 01/21/2010 for the amount $8500.0</p>
-<p>Check #14491 dated 01/26/2010 for the amount $5695.0</p>
-<p>Check #14497 dated 02/01/2010 for the amount $6612.05</p>
-<p>Check #14501 dated 02/01/2010 for the amount $32894.0</p>
 <p>Check #14506 dated 02/03/2010 for the amount $38448.49</p>
 <p>Check #14509 dated 02/03/2010 for the amount $36673.28</p>
 <p>Check #14535 dated 02/17/2010 for the amount $8500.0</p>


### PR DESCRIPTION
Via Muckrock, I [requested](https://www.muckrock.com/foi/chicago-169/1505ml-checks-14470-through-14501-22227/) checks 14470, 14471, 14491, 14497, and 14501 on 2015-11-02.