### PR TITLE
Markdown to convert text into nicer format

### DIFF
--- a/canary/canary.html
+++ b/canary/canary.html
@@ -5,7 +5,8 @@ title: Warrant Canary
 
       <section>
       <h1>Warrant Canary</h1>
-<p>-----BEGIN PGP SIGNED MESSAGE-----
+```
+-----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA1
 
 We have not been contacted by any government agencies requesting information about our workshop attendees or website visitors. This post will be updated monthly. Last updated November 6th 2015.
@@ -26,8 +27,9 @@ nA+LxaKLjast30MX+4OsQaMNzqLGkYz9LLWDDzEAvEfcUVmdEPwkKvxLP9o+0M6z
 VYsXhFmfLbKCBg8cCLho
 =NrdS
 -----END PGP SIGNATURE-----
-</p>
+```
  
-<p>This message can be updated with any LPL member's GPG key. <a href="https://canarywatch.org/" target="_blank">What the heck is this?</a>  
-	</p>
+```
+This message can be updated with any LPL member's GPG key. <a href="https://canarywatch.org/" target="_blank">What the heck is this?</a>  
+``` 
       </section>


### PR DESCRIPTION
This *should* fix the formatting on our warrant canary page.