### PR TITLE
readd missing div tag, caused navigation to render improperly

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -9,4 +9,4 @@ noindex: false
 		{% include _pagination.html %}
 	</div><!-- /.medium-7.columns -->
 
-<!-- /.row -->
+</div><!-- /.row -->


### PR DESCRIPTION
fixes current trello board, tested locally and it renders properly. 