### PR TITLE
Switch over to relative links for CSP header compliance

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ slogan: "Governments never lead; they follow progress."
 
 
 # The description is used on homepage and in the footer to quickly describe your website. Use a maximum of 150 characters for SEO-purposes.
-description: "»Lucy Parsons Labs« is a charitable Chicago-based collaboration between data scientists, transparency activists, and technologists which focuses on the intersection of digital rights and on-the-streets issues."
+description: "Lucy Parsons Labs is a charitable Chicago-based collaboration between data scientists, transparency activists, and technologists which focuses on the intersection of digital rights and on-the-streets issues."
 
 # Main author of the website
 # See > authors.yml
@@ -29,7 +29,7 @@ baseurl: ''
 
 # This is for the editing function in _/includes/improve_content
 # Leave it empty if your site is not on GitHub/GitHub Pages
-improve_content: https://github.com/lucyparsons/lucyparsons.github.io
+improve_content: ''
 
 # This URL points directly to the images directory making
 # things easier to link to images in posts and templates. It needs a slash at the end.
@@ -37,7 +37,7 @@ improve_content: https://github.com/lucyparsons/lucyparsons.github.io
 # Example: <img src="{{ site.urlimg }}{{ post.image.title }}" />
 # Markdown-Example for posts ![Image Text]({{ site.urlimg }}image.jpg)
 #
-urlimg: 'https://www.lucyparsonslabs.com/images/'
+urlimg: '/images/'
 
 
 # Logo size is 600x80 pixels
@@ -72,7 +72,7 @@ exclude:
     - LICENSE
     - README.md
     - INSTALL.md
-
+    - Rakefile
 
 # The language setting is used in /includes/header.html for html-settings
 language: "en"

--- a/_config_staging.yml
+++ b/_config_staging.yml
@@ -1,3 +1,6 @@
+# Staging-specific overrides for the site
+#
+
 # This URL is the main address for absolute links. Don't include a slash at the end.
 #
 url: 'https://staging.lucyparsonslabs.com'

--- a/_includes/_footer_scripts.html
+++ b/_includes/_footer_scripts.html
@@ -5,7 +5,7 @@ $('audio,video').mediaelementplayer();
 {% endif %}
 
 
-<script src="{{ site.url }}{{ site.baseurl }}/assets/js/javascript.min.js"></script>
+<script src="/assets/js/javascript.min.js"></script>
 
 
 {% if page.header.image_fullwidth %}

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,8 +1,8 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>{% if page.meta_title %}{{ page.meta_title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-	<link rel="stylesheet" type="text/css" href="{{ site.url }}{{ site.baseurl }}/assets/css/styles_feeling_responsive.css" />
-	<script src="{{ site.url }}{{ site.baseurl }}/assets/js/modernizr.min.js"></script>
+	<link rel="stylesheet" type="text/css" href="/assets/css/styles_feeling_responsive.css" />
+	<script src="/assets/js/modernizr.min.js"></script>
 
 
   {% if site.google_site_verification %}<meta name="google-site-verification" content="{{ site.google_site_verification}}" />{% endif %}
@@ -30,8 +30,8 @@
 	<link type="text/plain" rel="author" href="{{ site.url }}{{ site.baseurl }}/humans.txt" />
 
 	{% if page.mediaplayer == true %}
-		<script src="{{ site.url }}{{ site.baseurl }}/assets/mediaelement_js/mediaelement-and-player.min.js"></script>
-		<link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/assets/mediaelement_js/mediaelementplayer.min.css" />
+		<script src="/assets/mediaelement_js/mediaelement-and-player.min.js"></script>
+		<link rel="stylesheet" href="/assets/mediaelement_js/mediaelementplayer.min.css" />
 	{% endif %}
 
 	{% unless page.style == NULL %}

--- a/_posts/2016-03-26-SecureDrop.md
+++ b/_posts/2016-03-26-SecureDrop.md
@@ -16,7 +16,7 @@ tags:
 #
 header: no
 image: 
- thumb: "thumbs/black-rose.jpg"
+ thumb: "thumbs/blackrose.jpg"
 ---
 
 SecureDrop is an _open-source_ whistleblower platform built on anonymity and strong encryption to protect data and the identity of sources. Lucy Parsons Labs has built an instance of SecureDrop that we are naming **"Black Rose"** and are proud to announce that it is now live. SecureDrop relies on several excellent technical projects and is completely segmented from other infrastructure that LPL uses. Since our servers are running as a Tor Hidden Service, submissions will not be tied to any personal information including IP addresses, names, or physical locations. 


### PR DESCRIPTION
A bunch of our stuff was being hard-coded as https://baseurl/assets or,
more confusingly, https://lucyparsonslabs.com/images/, which made trying
to make CSP headers that didn't break the site and weren't restrictive
annoyingly difficult.

Since the site is accessible as both www.lucyparsonslabs.com and
lucyparsonslabs.com, we might as well serve up relative links to the
content in question. _config.yml has the meat of it, but some changes
were required in the header and footer_scripts to serve the stuff out of
where we wanted it to come from.

We can now live without fear of baseurl.

Also fixed the Black Rose blogpost's thumbnail, since it was 404ing.